### PR TITLE
input/textareaの右余白の問題を修正

### DIFF
--- a/packages/web/src/components/NoteItem.tsx
+++ b/packages/web/src/components/NoteItem.tsx
@@ -65,6 +65,7 @@ export function NoteItem({
 						fontSize: "14px",
 						border: "1px solid #ccc",
 						borderRadius: "4px",
+						boxSizing: "border-box",
 					}}
 				/>
 			</div>
@@ -93,6 +94,7 @@ export function NoteItem({
 						border: "1px solid #ccc",
 						borderRadius: "4px",
 						resize: "vertical",
+						boxSizing: "border-box",
 					}}
 				/>
 			</div>


### PR DESCRIPTION
## Summary
- input/textareaの右に余白がない問題を修正しました
- `box-sizing: border-box`を追加することで、paddingとborderを含めて`width: 100%`が計算されるようになります

## Changes
- `NoteItem.tsx`のinputとtextareaに`boxSizing: "border-box"`を追加

## Test plan
- [x] ビルドが成功することを確認
- [ ] ブラウザで表示を確認し、input/textareaの右に適切な余白があることを確認
- [ ] GitHub Actionsのテストが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)