### PR TITLE
Change empty note message to "ノートを選択してね"

### DIFF
--- a/packages/web/src/components/NoteEditor.test.tsx
+++ b/packages/web/src/components/NoteEditor.test.tsx
@@ -23,7 +23,7 @@ describe("NoteEditor", () => {
 			<NoteEditor note={null} onUpdate={mockUpdate} onDelete={mockDelete} />,
 		);
 
-		expect(screen.getByText("ノートを選択してください")).toBeTruthy();
+		expect(screen.getByText("ノートを選択してね")).toBeTruthy();
 	});
 
 	test("should display note title and content", () => {
@@ -66,7 +66,7 @@ describe("NoteEditor", () => {
 
 	test("should call onUpdate when title is changed", () => {
 		let updatedTitle = "";
-		const mockUpdate = (id: string, title: string, content: string) => {
+		const mockUpdate = (_id: string, title: string, _content: string) => {
 			updatedTitle = title;
 		};
 		const mockDelete = () => {};
@@ -89,7 +89,7 @@ describe("NoteEditor", () => {
 
 	test("should call onUpdate when content is changed", () => {
 		let updatedContent = "";
-		const mockUpdate = (id: string, title: string, content: string) => {
+		const mockUpdate = (_id: string, _title: string, content: string) => {
 			updatedContent = content;
 		};
 		const mockDelete = () => {};
@@ -128,7 +128,7 @@ describe("NoteEditor", () => {
 	test("should call onDelete when delete button is clicked and confirmed", () => {
 		let deleteCalled = false;
 		const mockUpdate = () => {};
-		const mockDelete = (id: string) => {
+		const mockDelete = (_id: string) => {
 			deleteCalled = true;
 		};
 
@@ -156,7 +156,7 @@ describe("NoteEditor", () => {
 	test("should not call onDelete when delete is cancelled", () => {
 		let deleteCalled = false;
 		const mockUpdate = () => {};
-		const mockDelete = (id: string) => {
+		const mockDelete = (_id: string) => {
 			deleteCalled = true;
 		};
 

--- a/packages/web/src/components/NoteEditor.tsx
+++ b/packages/web/src/components/NoteEditor.tsx
@@ -29,7 +29,7 @@ export function NoteEditor({
 					fontSize: "16px",
 				}}
 			>
-				ノートを選択してください
+				ノートを選択してね
 			</div>
 		);
 	}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -5,11 +5,8 @@ declare const __GIT_COMMIT_DATE__: string;
 declare const __GIT_BRANCH__: string;
 
 declare global {
-	// biome-ignore lint/style/noVar: Required for global type extension
 	var __GIT_COMMIT_HASH__: string;
-	// biome-ignore lint/style/noVar: Required for global type extension
 	var __GIT_COMMIT_DATE__: string;
-	// biome-ignore lint/style/noVar: Required for global type extension
 	var __GIT_BRANCH__: string;
 }
 


### PR DESCRIPTION
## Summary
- ノート未選択時のメッセージを「ノートを選択してください」から「ノートを選択してね」に変更
- テストも同時に更新し、すべてのテストが成功
- Lintチェック、型チェック、ビルドすべて成功

## Test plan
- [x] 全テストケースが成功（17/17 pass）
- [x] Lintチェックが成功
- [x] 型チェックが成功
- [x] ビルドが成功

## Changes
- `packages/web/src/components/NoteEditor.tsx`: メッセージテキストを変更
- `packages/web/src/components/NoteEditor.test.tsx`: テスト文字列を更新し、未使用パラメータ警告を修正
- `packages/web/src/vite-env.d.ts`: biome-ignoreコメントを整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)