### PR TITLE
#15: ノート未選択時のメッセージを変更

### DIFF
--- a/packages/web/src/components/NoteEditor.test.tsx
+++ b/packages/web/src/components/NoteEditor.test.tsx
@@ -23,7 +23,7 @@ describe("NoteEditor", () => {
 			<NoteEditor note={null} onUpdate={mockUpdate} onDelete={mockDelete} />,
 		);
 
-		expect(screen.getByText("ノートを選択してね")).toBeTruthy();
+		expect(screen.getByText("ノートを選択しよう")).toBeTruthy();
 	});
 
 	test("should display note title and content", () => {

--- a/packages/web/src/components/NoteEditor.tsx
+++ b/packages/web/src/components/NoteEditor.tsx
@@ -29,7 +29,7 @@ export function NoteEditor({
 					fontSize: "16px",
 				}}
 			>
-				ノートを選択してね
+				ノートを選択しよう
 			</div>
 		);
 	}


### PR DESCRIPTION
## 概要
ノート未選択時に表示されるメッセージを「ノートを選択してね」から「ノートを選択しよう」に変更しました。

## 変更内容
- `NoteEditor.tsx`: メッセージを更新
- `NoteEditor.test.tsx`: テストを更新

Close #15