### PR TITLE
#30: 複数選択中のノート新規作成時に全選択をクリアする

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -51,6 +51,7 @@ export function App(): ReactElement {
 		};
 		setNotes((prevNotes) => [newNote, ...prevNotes]);
 		setSelectedNoteId(newNote.id);
+		setSelectedNoteIds(new Set());
 	};
 
 	const handleUpdateNote = (id: string, title: string, content: string) => {

--- a/packages/web/src/components/NoteListSidebar.test.tsx
+++ b/packages/web/src/components/NoteListSidebar.test.tsx
@@ -363,4 +363,5 @@ describe("NoteListSidebar", () => {
 		// Happy DOM returns hex colors
 		expect(selectedNoteItem.style.backgroundColor).toBe("#e7f3ff");
 	});
+
 });


### PR DESCRIPTION
## 概要
複数選択状態でノート作成時に、選択中のすべてのノート選択をクリアするように修正しました。

## 変更内容
- `handleAddNote` 関数に `setSelectedNoteIds(new Set())` を追加
- 新規ノート作成時に複数選択状態を明示的にクリア
- これにより、新規作成されたノートのみが正しく選択状態になります

## テスト
既存の全テストがパスしていることを確認しました。

Close #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)