### PR TITLE
#34: ノート選択ロジックの統一

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -29,10 +29,7 @@ export function App(): ReactElement {
 		return [];
 	});
 
-	const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
-	const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(
-		new Set(),
-	);
+	const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
 
 	useEffect(() => {
 		try {
@@ -50,8 +47,7 @@ export function App(): ReactElement {
 			createdAt: new Date(),
 		};
 		setNotes((prevNotes) => [newNote, ...prevNotes]);
-		setSelectedNoteId(newNote.id);
-		setSelectedNoteIds(new Set());
+		setSelectedNoteIds([newNote.id]);
 	};
 
 	const handleUpdateNote = (id: string, title: string, content: string) => {
@@ -64,57 +60,54 @@ export function App(): ReactElement {
 
 	const handleDeleteNote = (id: string) => {
 		setNotes((prevNotes) => prevNotes.filter((note) => note.id !== id));
-		if (selectedNoteId === id) {
-			setSelectedNoteId(null);
-		}
+		setSelectedNoteIds((prev) => prev.filter((noteId) => noteId !== id));
 	};
 
 	const handleSelectNote = (id: string, modifierKey: boolean) => {
 		if (modifierKey) {
 			// Ctrl/Meta キーが押されている場合は複数選択
 			setSelectedNoteIds((prev) => {
-				const newSet = new Set(prev);
-				if (newSet.has(id)) {
-					newSet.delete(id);
+				if (prev.includes(id)) {
+					return prev.filter((noteId) => noteId !== id);
 				} else {
-					newSet.add(id);
+					return [...prev, id];
 				}
-				return newSet;
 			});
 		} else {
 			// Ctrl/Meta キーが押されていない場合は通常選択
-			setSelectedNoteIds(new Set());
-			setSelectedNoteId(id);
+			setSelectedNoteIds([id]);
 		}
 	};
 
 	const handleDeleteSelectedNotes = () => {
-		if (selectedNoteIds.size === 0) return;
+		if (selectedNoteIds.length === 0) return;
 
 		const confirmed = window.confirm(
-			`${selectedNoteIds.size}個のノートを削除しますか？`,
+			`${selectedNoteIds.length}個のノートを削除しますか？`,
 		);
 		if (!confirmed) return;
 
+		const selectedSet = new Set(selectedNoteIds);
 		setNotes((prevNotes) =>
-			prevNotes.filter((note) => !selectedNoteIds.has(note.id)),
+			prevNotes.filter((note) => !selectedSet.has(note.id)),
 		);
-		setSelectedNoteIds(new Set());
-		setSelectedNoteId(null);
+		setSelectedNoteIds([]);
 	};
 
 	const handleCancelSelection = () => {
-		setSelectedNoteIds(new Set());
+		setSelectedNoteIds([]);
 	};
 
-	const selectedNote = notes.find((note) => note.id === selectedNoteId) || null;
+	const selectedNote =
+		selectedNoteIds.length > 0
+			? notes.find((note) => note.id === selectedNoteIds[0]) || null
+			: null;
 
 	return (
 		<Layout
 			sidebar={
 				<NoteListSidebar
 					notes={notes}
-					selectedNoteId={selectedNoteId}
 					selectedNoteIds={selectedNoteIds}
 					onSelectNote={handleSelectNote}
 					onAddNote={handleAddNote}

--- a/packages/web/src/components/NoteListSidebar.test.tsx
+++ b/packages/web/src/components/NoteListSidebar.test.tsx
@@ -37,8 +37,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -58,8 +57,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={[]}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -80,8 +78,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -111,8 +108,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={notesWithoutTitle}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -135,8 +131,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -162,8 +157,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -190,8 +184,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -218,8 +211,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set()}
+				selectedNoteIds={[]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -243,8 +235,7 @@ describe("NoteListSidebar", () => {
 		const { container } = render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId="1"
-				selectedNoteIds={new Set()}
+				selectedNoteIds={["1"]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -269,8 +260,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set(["1", "2"])}
+				selectedNoteIds={["1", "2"]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -296,8 +286,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set(["1", "2"])}
+				selectedNoteIds={["1", "2"]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -323,8 +312,7 @@ describe("NoteListSidebar", () => {
 		render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set(["1", "2"])}
+				selectedNoteIds={["1", "2"]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}
@@ -347,8 +335,7 @@ describe("NoteListSidebar", () => {
 		const { container } = render(
 			<NoteListSidebar
 				notes={mockNotes}
-				selectedNoteId={null}
-				selectedNoteIds={new Set(["1"])}
+				selectedNoteIds={["1"]}
 				onSelectNote={mockSelectNote}
 				onAddNote={mockAddNote}
 				onDeleteSelectedNotes={mockDeleteSelectedNotes}

--- a/packages/web/src/components/NoteListSidebar.tsx
+++ b/packages/web/src/components/NoteListSidebar.tsx
@@ -9,8 +9,7 @@ import { BuildInfo } from "./BuildInfo.js";
 
 interface NoteListSidebarProps {
 	notes: Note[];
-	selectedNoteId: string | null;
-	selectedNoteIds: Set<string>;
+	selectedNoteIds: string[];
 	onSelectNote: (id: string, modifierKey: boolean) => void;
 	onAddNote: () => void;
 	onDeleteSelectedNotes: () => void;
@@ -19,7 +18,6 @@ interface NoteListSidebarProps {
 
 export function NoteListSidebar({
 	notes,
-	selectedNoteId,
 	selectedNoteIds,
 	onSelectNote,
 	onAddNote,
@@ -43,7 +41,7 @@ export function NoteListSidebar({
 				<h2 style={{ margin: "0 0 12px 0", fontSize: "18px" }}>
 					ノート一覧 ({notes.length}件)
 				</h2>
-				{selectedNoteIds.size >= 2 ? (
+				{selectedNoteIds.length >= 2 ? (
 					<div
 						style={{
 							display: "flex",
@@ -77,7 +75,7 @@ export function NoteListSidebar({
 								e.currentTarget.style.backgroundColor = "#dc3545";
 							}}
 						>
-							削除 ({selectedNoteIds.size}個)
+							削除 ({selectedNoteIds.length}個)
 						</button>
 						<button
 							type="button"
@@ -173,43 +171,31 @@ export function NoteListSidebar({
 									borderBottom: "1px solid #ddd",
 									cursor: "pointer",
 									backgroundColor:
-										selectedNoteId === note.id || selectedNoteIds.has(note.id)
+										selectedNoteIds.includes(note.id)
 											? "#e7f3ff"
 											: "transparent",
 									transition: "background-color 0.2s",
 									textAlign: "left",
 								}}
 								onMouseOver={(e) => {
-									if (
-										selectedNoteId !== note.id &&
-										!selectedNoteIds.has(note.id)
-									) {
+									if (!selectedNoteIds.includes(note.id)) {
 										e.currentTarget.style.backgroundColor = "#f0f0f0";
 									}
 								}}
 								onMouseOut={(e) => {
-									if (
-										selectedNoteId === note.id ||
-										selectedNoteIds.has(note.id)
-									) {
+									if (selectedNoteIds.includes(note.id)) {
 										e.currentTarget.style.backgroundColor = "#e7f3ff";
 									} else {
 										e.currentTarget.style.backgroundColor = "transparent";
 									}
 								}}
 								onFocus={(e) => {
-									if (
-										selectedNoteId !== note.id &&
-										!selectedNoteIds.has(note.id)
-									) {
+									if (!selectedNoteIds.includes(note.id)) {
 										e.currentTarget.style.backgroundColor = "#f0f0f0";
 									}
 								}}
 								onBlur={(e) => {
-									if (
-										selectedNoteId === note.id ||
-										selectedNoteIds.has(note.id)
-									) {
+									if (selectedNoteIds.includes(note.id)) {
 										e.currentTarget.style.backgroundColor = "#e7f3ff";
 									} else {
 										e.currentTarget.style.backgroundColor = "transparent";
@@ -219,9 +205,7 @@ export function NoteListSidebar({
 								<div
 									style={{
 										fontWeight:
-											selectedNoteId === note.id || selectedNoteIds.has(note.id)
-												? "bold"
-												: "normal",
+											selectedNoteIds.includes(note.id) ? "bold" : "normal",
 										marginBottom: "4px",
 										fontSize: "14px",
 										overflow: "hidden",


### PR DESCRIPTION
## 概要

`selectedNoteId` と `selectedNoteIds` を統一しました。

チケット要件に基づいて、`selectedNoteIds` (配列) のみを使用するよう実装を整理しました。単一選択時は配列の先頭、複数選択時は配列全体を使用します。

## 変更内容

- **App.tsx**: 
  - `selectedNoteId` と `selectedNoteIds` を統一して `selectedNoteIds: string[]` のみに
  - `handleSelectNote()`: 配列操作に更新
  - `handleDeleteSelectedNotes()`: 配列の長さを確認
  - `selectedNote` の計算: `selectedNoteIds[0]` から取得

- **NoteListSidebar.tsx**:
  - Props インターフェイスから `selectedNoteId` を削除
  - `selectedNoteIds` を `string[]` 型に統一
  - ノート選択判定ロジックを配列 `.includes()` に統一

- **NoteListSidebar.test.tsx**:
  - すべてのテストケースを配列形式に統一
  - `new Set()` を `[]` に変更
  - `new Set(["1", "2"])` を `["1", "2"]` に変更

## テスト

TypeScript コンパイルチェック: ✅ 合格

## Close

Close #34